### PR TITLE
try to load the entire poll list to find a poll if it isn't immediately found upon landing on a poll details page

### DIFF
--- a/src/pages/Polling.js
+++ b/src/pages/Polling.js
@@ -14,7 +14,6 @@ import NotFound from './NotFound';
 import { VotingWeightBanner } from './PollingList';
 import { activeCanVote, getActiveVotingFor } from '../reducers/accounts';
 import { modalOpen } from '../reducers/modal';
-import { getWinningProp } from '../reducers/proposals';
 import {
   getOptionVotingFor,
   getOptionVotingForRankedChoice,
@@ -662,8 +661,7 @@ class Polling extends React.Component {
   }
 
   componentDidMount() {
-    if (!!this.props.poll)
-      this.props.pollDataInit(this.props.poll, this.props.pollSlug);
+    this.props.pollDataInit(this.props.poll, this.props.pollSlug);
     this.updateVotedPollOption();
   }
 

--- a/src/pages/PollingList.js
+++ b/src/pages/PollingList.js
@@ -221,7 +221,7 @@ const PollingList = ({
   approvals,
   pollsFetching
 }) => {
-  polls.sort((a, b) => b.startDate - a.startDate);
+  polls.sort((a, b) => b.endDate - a.endDate);
   const winningProposal = poll => {
     if (poll.legacyPoll) {
       const wp = getWinningProp({ proposals, approvals }, poll.pollId);


### PR DESCRIPTION
previously some old polls weren't loading if you linked directly to them (eg `/polling-proposal/qmas1bqrquo2h41qv4fa8hpek9ukb7dlwtpkpn62r5hhmq`). this was especially problematic for old MIPs that linked to relevent polls. this pr aims to fix that.
also sort polls by end date rather than start date.